### PR TITLE
Fix NSGA-III domination sort guard

### DIFF
--- a/nsga3_algorithm.py
+++ b/nsga3_algorithm.py
@@ -227,7 +227,7 @@ class SimpleNSGA3:
 
         # Build subsequent fronts
         current_front = 0
-        while fronts[current_front]:
+        while current_front < len(fronts) and fronts[current_front]:
             next_front = []
             for i in fronts[current_front]:
                 for j in dominated_solutions[i]:
@@ -645,7 +645,7 @@ class AdvancedNSGA3:
                 fronts[0].append(i)
 
         current_front = 0
-        while fronts[current_front]:
+        while current_front < len(fronts) and fronts[current_front]:
             next_front = []
             for i in fronts[current_front]:
                 for j in dominated_solutions[i]:

--- a/tests/test_domination_sort.py
+++ b/tests/test_domination_sort.py
@@ -1,0 +1,13 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+import nsga3_algorithm as nsga
+
+
+def test_domination_sort_single_front():
+    obj = [[1, 2]]
+    simple = object.__new__(nsga.SimpleNSGA3)
+    advanced = object.__new__(nsga.AdvancedNSGA3)
+    assert simple.domination_sort(obj) == [[0]]
+    assert advanced.domination_sort(obj) == [[0]]
+


### PR DESCRIPTION
## Summary
- avoid index error in both `SimpleNSGA3` and `AdvancedNSGA3` when running domination sort
- add minimal unit test for `domination_sort`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615415d67c8322a22f5a4361f45815