### PR TITLE
Enforce even zeta values

### DIFF
--- a/bayesian_optimization.py
+++ b/bayesian_optimization.py
@@ -267,12 +267,15 @@ class BayesianOptimization:
         else:
             # Fallback: generate random and repair
             print("⚠️ BO: Could not generate valid individual, using repair method")
+            zmin = self.param_bounds['zeta']['min']
+            if zmin % 2 != 0:
+                zmin += 1
             individual = np.array([
                 random.uniform(self.param_bounds['dK']['min'], self.param_bounds['dK']['max']),
                 random.uniform(self.param_bounds['dZ']['min'], self.param_bounds['dZ']['max']),
                 random.uniform(self.param_bounds['lK']['min'], self.param_bounds['lK']['max']),
                 random.uniform(self.param_bounds['lF']['min'], self.param_bounds['lF']['max']),
-                random.randint(self.param_bounds['zeta']['min'], self.param_bounds['zeta']['max'])
+                random.choice(list(range(zmin, self.param_bounds['zeta']['max'] + 1, 2)))
             ])
 
             param_dict = {self.param_names[i]: individual[i] for i in range(len(self.param_names))}

--- a/constraints.py
+++ b/constraints.py
@@ -181,12 +181,15 @@ class ConstraintManager:
 
         for attempt in range(max_attempts):
             # Generate random parameters within bounds
+            start = normalized_bounds['zeta']['min']
+            if start % 2 != 0:
+                start += 1
             params = {
                 'dK': random.uniform(normalized_bounds['dK']['min'], normalized_bounds['dK']['max']),
                 'dZ': random.uniform(normalized_bounds['dZ']['min'], normalized_bounds['dZ']['max']),
                 'lK': random.uniform(normalized_bounds['lK']['min'], normalized_bounds['lK']['max']),
                 'lF': random.uniform(normalized_bounds['lF']['min'], normalized_bounds['lF']['max']),
-                'zeta': random.randint(normalized_bounds['zeta']['min'], normalized_bounds['zeta']['max'])
+                'zeta': random.choice(list(range(start, normalized_bounds['zeta']['max'] + 1, 2)))
             }
 
             # Check if parameters satisfy all constraints
@@ -250,6 +253,16 @@ class ConstraintManager:
                 repaired['dZ'] = normalized_bounds['dZ']['max']
                 repaired['dK'] = repaired['dZ'] - max_diff
                 repaired['dK'] = max(repaired['dK'], normalized_bounds['dK']['min'])
+
+        # Ensure zeta is even and within bounds
+        zmin = normalized_bounds['zeta']['min']
+        zmax = normalized_bounds['zeta']['max']
+        zeta_even = int(round(repaired.get('zeta', zmin) / 2.0)) * 2
+        if zeta_even < zmin:
+            zeta_even = zmin if zmin % 2 == 0 else zmin + 1
+        if zeta_even > zmax:
+            zeta_even = zmax if zmax % 2 == 0 else zmax - 1
+        repaired['zeta'] = zeta_even
 
         return repaired
 

--- a/nsga3_algorithm.py
+++ b/nsga3_algorithm.py
@@ -115,12 +115,15 @@ class SimpleNSGA3:
         else:
             # Fallback: generate random and try to repair
             print("⚠️ Could not generate valid individual, using repair method")
+            zmin = self.param_bounds['zeta']['min']
+            if zmin % 2 != 0:
+                zmin += 1
             individual = [
                 random.uniform(self.param_bounds['dK']['min'], self.param_bounds['dK']['max']),
                 random.uniform(self.param_bounds['dZ']['min'], self.param_bounds['dZ']['max']),
                 random.uniform(self.param_bounds['lK']['min'], self.param_bounds['lK']['max']),
                 random.uniform(self.param_bounds['lF']['min'], self.param_bounds['lF']['max']),
-                random.randint(self.param_bounds['zeta']['min'], self.param_bounds['zeta']['max'])
+                random.choice(list(range(zmin, self.param_bounds['zeta']['max'] + 1, 2)))
             ]
 
             # Try to repair
@@ -428,12 +431,15 @@ class AdvancedNSGA3:
         else:
             # Fallback: generate random and try to repair
             print("⚠️ Could not generate valid individual, using repair method")
+            zmin = self.param_bounds['zeta']['min']
+            if zmin % 2 != 0:
+                zmin += 1
             individual = [
                 random.uniform(self.param_bounds['dK']['min'], self.param_bounds['dK']['max']),
                 random.uniform(self.param_bounds['dZ']['min'], self.param_bounds['dZ']['max']),
                 random.uniform(self.param_bounds['lK']['min'], self.param_bounds['lK']['max']),
                 random.uniform(self.param_bounds['lF']['min'], self.param_bounds['lF']['max']),
-                random.randint(self.param_bounds['zeta']['min'], self.param_bounds['zeta']['max'])
+                random.choice(list(range(zmin, self.param_bounds['zeta']['max'] + 1, 2)))
             ]
 
             # Try to repair
@@ -714,7 +720,12 @@ class AdvancedNSGA3:
             bounds = self.param_bounds[param_name]
 
             if param_name == 'zeta':
-                child_val = max(bounds['min'], min(bounds['max'], int(round(child_val))))
+                even_val = int(round(child_val / 2.0)) * 2
+                if even_val < bounds['min']:
+                    even_val = bounds['min'] if bounds['min'] % 2 == 0 else bounds['min'] + 1
+                if even_val > bounds['max']:
+                    even_val = bounds['max'] if bounds['max'] % 2 == 0 else bounds['max'] - 1
+                child_val = even_val
             else:
                 child_val = max(bounds['min'], min(bounds['max'], child_val))
 
@@ -751,7 +762,12 @@ class AdvancedNSGA3:
                 y = y + deltaq * (bounds['max'] - bounds['min'])
 
                 if param_name == 'zeta':
-                    y = max(bounds['min'], min(bounds['max'], int(round(y))))
+                    even_y = int(round(y / 2.0)) * 2
+                    if even_y < bounds['min']:
+                        even_y = bounds['min'] if bounds['min'] % 2 == 0 else bounds['min'] + 1
+                    if even_y > bounds['max']:
+                        even_y = bounds['max'] if bounds['max'] % 2 == 0 else bounds['max'] - 1
+                    y = even_y
                 else:
                     y = max(bounds['min'], min(bounds['max'], y))
 

--- a/tests/test_even_zeta.py
+++ b/tests/test_even_zeta.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import random
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import constraints
+np = pytest.importorskip("numpy")
+import nsga3_algorithm as nsga
+import bayesian_optimization as bo
+
+param_bounds = {
+    'dK': {'min': 19.0, 'max': 20.0},
+    'dZ': {'min': 19.2, 'max': 20.5},
+    'lK': {'min': 50.0, 'max': 70.0},
+    'lF': {'min': 30.0, 'max': 40.0},
+    'zeta': {'min': 3, 'max': 7}
+}
+
+
+def test_generate_valid_parameters_even_zeta():
+    cm = constraints.ConstraintManager()
+    params = cm.generate_valid_parameters(param_bounds, max_attempts=100)
+    assert params is not None
+    assert params[4] % 2 == 0
+
+
+def test_simple_generate_individual_even_zeta():
+    alg = object.__new__(nsga.SimpleNSGA3)
+    alg.param_bounds = param_bounds
+    alg.constraint_manager = constraints.ConstraintManager()
+    individual = alg.generate_individual()
+    assert individual[4] % 2 == 0
+
+
+def test_advanced_generate_individual_even_zeta():
+    alg = object.__new__(nsga.AdvancedNSGA3)
+    alg.param_bounds = param_bounds
+    alg.constraint_manager = constraints.ConstraintManager()
+    alg.n_partitions = 4
+    individual = alg.generate_individual()
+    assert individual[4] % 2 == 0
+def test_bo_generate_individual_even_zeta():
+    alg = object.__new__(bo.BayesianOptimization)
+    alg.param_bounds = param_bounds
+    alg.param_names = ['dK', 'dZ', 'lK', 'lF', 'zeta']
+    alg.constraint_manager = constraints.ConstraintManager()
+    individual = alg.generate_individual()
+    assert individual[4] % 2 == 0
+
+
+def test_polynomial_mutation_even_zeta(monkeypatch):
+    alg = object.__new__(nsga.SimpleNSGA3)
+    alg.param_bounds = param_bounds
+    alg.constraint_manager = constraints.ConstraintManager()
+
+    def fake_random():
+        return 0.0
+
+    monkeypatch.setattr(random, "random", fake_random)
+    mutated = alg.polynomial_mutation([19.2, 19.8, 60.0, 35.0, 5])
+    assert mutated[4] % 2 == 0
+
+


### PR DESCRIPTION
## Summary
- ensure `zeta` sampling uses even integers across algorithms
- round `zeta` to the nearest even value when repairing or mutating
- add unit tests confirming even `zeta` values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bdcda0108322967f3d9ddc275486